### PR TITLE
feat: Enhance Yandex Cloud SpeechKit STT node with format specificati…

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,9 @@ Collection of message attributes with configuration:
 | **Operation** | Options | Recognize Audio or Get Recognition Results |
 | **Audio URL** | String | URL of audio file in Yandex Object Storage |
 | **Language Code** | Options | Language for recognition (auto-detect, Russian, English, etc.) |
-| **Audio Format** | Options | Audio file format (LPCM, OGG Opus, MP3) |
+| **Format Specification** | Options | Choose to specify format using Audio Format codes or MIME Types |
+| **Audio Format** | Options | Yandex Cloud audio format (LPCM, OGG Opus, MP3) - shown when Format Specification is "Audio Format" |
+| **MIME Type** | Options | Standard MIME type (audio/wav, audio/ogg, audio/mpeg, etc.) - shown when Format Specification is "MIME Type" |
 
 **Operations:**
 
@@ -416,9 +418,19 @@ Collection of message attributes with configuration:
 
 **Audio Formats:**
 
+The node supports two ways to specify audio format:
+
+*Via Audio Format (Yandex Cloud format codes):*
+
 - **LPCM** - Linear PCM with configurable sample rate (8000, 16000, 48000 Hz)
 - **OGG Opus** - Compressed Ogg Opus format
 - **MP3** - Standard MP3 format
+
+*Via MIME Type (standard MIME types, automatically mapped to Yandex formats):*
+
+- **audio/wav, audio/pcm, audio/x-pcm** - Maps to LPCM
+- **audio/ogg, audio/opus** - Maps to OGG Opus
+- **audio/mpeg, audio/mp3** - Maps to MP3
 
 **Recognition Options:**
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -356,7 +356,9 @@
 | **Operation** | Options | Recognize Audio или Get Recognition Results |
 | **Audio URL** | String | URL аудиофайла в Yandex Object Storage |
 | **Language Code** | Options | Язык распознавания (авто-определение, русский, английский и др.) |
-| **Audio Format** | Options | Формат аудиофайла (LPCM, OGG Opus, MP3) |
+| **Format Specification** | Options | Выбор способа указания формата: коды Audio Format или MIME Types |
+| **Audio Format** | Options | Формат аудио Yandex Cloud (LPCM, OGG Opus, MP3) - отображается при выборе "Audio Format" |
+| **MIME Type** | Options | Стандартный MIME тип (audio/wav, audio/ogg, audio/mpeg и др.) - отображается при выборе "MIME Type" |
 
 **Операции:**
 
@@ -385,9 +387,19 @@
 
 **Форматы аудио:**
 
+Нода поддерживает два способа указания формата аудио:
+
+*Через Audio Format (коды форматов Yandex Cloud):*
+
 - **LPCM** - Linear PCM с настраиваемой частотой дискретизации (8000, 16000, 48000 Гц)
 - **OGG Opus** - Сжатый формат Ogg Opus
 - **MP3** - Стандартный формат MP3
+
+*Через MIME Type (стандартные MIME типы, автоматически преобразуются в форматы Yandex):*
+
+- **audio/wav, audio/pcm, audio/x-pcm** - Преобразуется в LPCM
+- **audio/ogg, audio/opus** - Преобразуется в OGG Opus
+- **audio/mpeg, audio/mp3** - Преобразуется в MP3
 
 **Опции распознавания:**
 

--- a/nodes/YandexCloudSpeechKitSTT/test/YandexCloudSpeechKitStt.node.test.ts
+++ b/nodes/YandexCloudSpeechKitSTT/test/YandexCloudSpeechKitStt.node.test.ts
@@ -145,6 +145,7 @@ describe('YandexCloudSpeechKitStt Node', () => {
 			.mockReturnValueOnce('recognizeAudio')
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.wav')
 			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('LPCM')
 			.mockReturnValueOnce({});
 
@@ -220,6 +221,7 @@ describe('YandexCloudSpeechKitStt Node', () => {
 		(mockExecuteFunctions.getNodeParameter as jest.Mock)
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.wav')
 			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('LPCM')
 			.mockReturnValueOnce({});
 
@@ -244,6 +246,7 @@ describe('YandexCloudSpeechKitStt Node', () => {
 		(mockExecuteFunctions.getNodeParameter as jest.Mock)
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.wav')
 			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('LPCM')
 			.mockReturnValueOnce({
 				sampleRate: 16000,
@@ -265,6 +268,7 @@ describe('YandexCloudSpeechKitStt Node', () => {
 		(mockExecuteFunctions.getNodeParameter as jest.Mock)
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.ogg')
 			.mockReturnValueOnce('en-US')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('OGG_OPUS')
 			.mockReturnValueOnce({});
 
@@ -286,6 +290,7 @@ describe('YandexCloudSpeechKitStt Node', () => {
 		(mockExecuteFunctions.getNodeParameter as jest.Mock)
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.mp3')
 			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('MP3')
 			.mockReturnValueOnce({
 				profanityFilter: true,
@@ -301,10 +306,71 @@ describe('YandexCloudSpeechKitStt Node', () => {
 		expect(result[0][0].json.success).toBe(true);
 	});
 
+	it('should recognize audio using MIME type (audio/wav)', async () => {
+		(mockExecuteFunctions.getNodeParameter as jest.Mock)
+			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.wav')
+			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('mimeType')
+			.mockReturnValueOnce('audio/wav')
+			.mockReturnValueOnce({});
+
+		mockAsyncRecognizerClient.recognizeFile.mockResolvedValue({
+			id: 'operation-mime-1',
+		});
+
+		const result = await node.execute.call(mockExecuteFunctions as IExecuteFunctions);
+
+		expect(result[0][0].json).toMatchObject({
+			success: true,
+			operationId: 'operation-mime-1',
+		});
+	});
+
+	it('should recognize audio using MIME type (audio/ogg)', async () => {
+		(mockExecuteFunctions.getNodeParameter as jest.Mock)
+			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.ogg')
+			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('mimeType')
+			.mockReturnValueOnce('audio/ogg')
+			.mockReturnValueOnce({});
+
+		mockAsyncRecognizerClient.recognizeFile.mockResolvedValue({
+			id: 'operation-mime-2',
+		});
+
+		const result = await node.execute.call(mockExecuteFunctions as IExecuteFunctions);
+
+		expect(result[0][0].json).toMatchObject({
+			success: true,
+			operationId: 'operation-mime-2',
+		});
+	});
+
+	it('should recognize audio using MIME type (audio/mpeg)', async () => {
+		(mockExecuteFunctions.getNodeParameter as jest.Mock)
+			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.mp3')
+			.mockReturnValueOnce('en-US')
+			.mockReturnValueOnce('mimeType')
+			.mockReturnValueOnce('audio/mpeg')
+			.mockReturnValueOnce({});
+
+		mockAsyncRecognizerClient.recognizeFile.mockResolvedValue({
+			id: 'operation-mime-3',
+		});
+
+		const result = await node.execute.call(mockExecuteFunctions as IExecuteFunctions);
+
+		expect(result[0][0].json).toMatchObject({
+			success: true,
+			operationId: 'operation-mime-3',
+		});
+	});
+
 	it('should handle API error in recognizeAudio', async () => {
 		(mockExecuteFunctions.getNodeParameter as jest.Mock)
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.wav')
 			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('LPCM')
 			.mockReturnValueOnce({});
 
@@ -321,6 +387,7 @@ describe('YandexCloudSpeechKitStt Node', () => {
 		(mockExecuteFunctions.getNodeParameter as jest.Mock)
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio.wav')
 			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('LPCM')
 			.mockReturnValueOnce({});
 
@@ -605,11 +672,13 @@ describe('YandexCloudSpeechKitStt Node', () => {
 			.mockReturnValueOnce('recognizeAudio')
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio1.wav')
 			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('LPCM')
 			.mockReturnValueOnce({})
 			.mockReturnValueOnce('recognizeAudio')
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio2.wav')
 			.mockReturnValueOnce('en-US')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('LPCM')
 			.mockReturnValueOnce({});
 
@@ -636,11 +705,13 @@ describe('YandexCloudSpeechKitStt Node', () => {
 			.mockReturnValueOnce('recognizeAudio')
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio1.wav')
 			.mockReturnValueOnce('ru-RU')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('LPCM')
 			.mockReturnValueOnce({})
 			.mockReturnValueOnce('recognizeAudio')
 			.mockReturnValueOnce('https://storage.yandexcloud.net/bucket/audio2.wav')
 			.mockReturnValueOnce('en-US')
+			.mockReturnValueOnce('audioFormat')
 			.mockReturnValueOnce('LPCM')
 			.mockReturnValueOnce({});
 


### PR DESCRIPTION
…on options

This commit introduces a new parameter for specifying audio format in the Yandex Cloud SpeechKit STT node, allowing users to choose between Yandex Cloud audio format codes and standard MIME types. The README files have been updated to reflect these changes, providing clearer guidance on audio format options. Additionally, unit tests have been added to ensure functionality for both format specification methods.